### PR TITLE
convert to extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,22 @@
+{
+	"name": "DonateBoxInSidebar",
+	"version": "1.2.0",
+	"author": [
+		"Suriyaa Sundararuban <contact@suriyaa.tk> (https://about.suriyaa.tk/)"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:DonateBoxInSidebar Documentation",
+	"descriptionmsg": "sidebardonatebox-desc",
+	"license-name": "GPL-2.0+",
+	"MessagesDirs": {
+		"DonateBoxInSidebar": [
+			"i18n"
+		]
+	},
+	"ExtensionMessagesFiles": {
+		"DonateBoxInSidebar": "DonateBoxInSidebar.i18n.php"
+	},
+	"Hooks": {
+		"SkinBuildSidebar": "DonateBoxInSidebar::efDonateBoxInSidebar"
+	},
+	"manifest_version": 1
+}


### PR DESCRIPTION
Extension.json is the new way of registering extensions.

Since there's only a master branch, I'm not removing the .php file for backwords compatibility, but if you want you can.